### PR TITLE
Count per-test valgrind leaks and show in report

### DIFF
--- a/examples/valgrind-error.c
+++ b/examples/valgrind-error.c
@@ -61,3 +61,11 @@ SCU_TEST(memory_leak, "Memory leak")
 	b[1] = 17;
 	SCU_ASSERT(b[1] == 17);
 }
+
+SCU_TEST(another_memory_leak, "Another memory leak")
+{
+	char *b = malloc(15);
+
+	b[1] = 17;
+	SCU_ASSERT(b[1] == 17);
+}

--- a/libscu-c/Makefile
+++ b/libscu-c/Makefile
@@ -4,6 +4,10 @@ ifneq ($(SCU_HAVE_VALGRIND),)
 CFLAGS+=-DSCU_HAVE_VALGRIND=1
 endif
 
+ifneq ($(SCU_VALGRIND_LEAK_LEVEL),)
+CFLAGS+=-DSCU_VALGRIND_LEAK_LEVEL=$(SCU_VALGRIND_LEAK_LEVEL)
+endif
+
 .PHONY: clean
 
 libscu-c.a: src/scu.o

--- a/testrunner
+++ b/testrunner
@@ -357,6 +357,9 @@ class TestEmitter(Observer):
             if event.get('valgrind_errors', 0):
                 print("           ! {colors.RED}{vgerrs} valgrind error(s){colors.DEFAULT} reported!"
                       .format(vgerrs=event['valgrind_errors'], colors=Colors))
+            if event.get('valgrind_leaks', 0):
+                print("           ! {colors.RED}{vgerrs}B leaked memory{colors.DEFAULT} reported!"
+                      .format(vgerrs=event['valgrind_leaks'], colors=Colors))
         elif event_type in ('testcase_error', 'module_crash'):
             print('')
             print("           ! " + event['message'])
@@ -386,6 +389,8 @@ class SummaryEmitter(Observer):
         self.has_reported_failing_test = {}
         self.tests_with_valgrind_errors_counter = 0
         self.valgrind_errors_counter = 0
+        self.tests_with_valgrind_leaks_counter = 0
+        self.valgrind_leaks_counter = 0
         self.show_valgrind_stats = False
 
     def handle_module_start(self, module, event):
@@ -403,6 +408,9 @@ class SummaryEmitter(Observer):
         if event.get('valgrind_errors', 0):
             self.tests_with_valgrind_errors_counter += 1
             self.valgrind_errors_counter += event['valgrind_errors']
+        if event.get('valgrind_leaks', 0):
+            self.tests_with_valgrind_leaks_counter += 1
+            self.valgrind_leaks_counter += event['valgrind_leaks']
 
     def handle_testcase_error(self, module, event):
         self.test_counter += 1
@@ -419,7 +427,8 @@ class SummaryEmitter(Observer):
             self.module_fail_counter += 1
 
     def is_failure(self):
-        return self.module_fail_counter > 0 or self.valgrind_errors_counter > 0
+        return self.module_fail_counter > 0 or self.valgrind_errors_counter > 0 or \
+               self.valgrind_leaks_counter > 0
 
     def print_summary(self):
         print("\n  Run summary:\n")
@@ -452,11 +461,15 @@ class SummaryEmitter(Observer):
                 "  | Valgrind           |            |\n"
                 "  +--------------------+------------+\n"
                 "  |            Errors: | {:10} |\n"
+                "  |          Leaks(B): | {:10} |\n"
                 "  | Tests with errors: | {:10} |\n"
+                "  |  Tests with leaks: [ {:10} |\n"
                 "  +--------------------+------------+\n"
             ).format(
                 self.valgrind_errors_counter,
+                self.valgrind_leaks_counter,
                 self.tests_with_valgrind_errors_counter,
+                self.tests_with_valgrind_leaks_counter,
             ))
 
 


### PR DESCRIPTION
When libscu-c is compiled with valgrind support, add ability to count
leaked memory based on SCU_VALGRIND_LEAK_LEVEL set using memcheck's
own definitions:
    [0 (or not defined) - none, 1 - leaked, 2 - dubious]
    
VALGRIND_DO_QUICK_LEAK_CHECK is used as it corresponds to
'--leak-check=summary'. Since we are not interested in the specifics
of where the leaks are this should suffice.
    
Fail test cases where leaks of the set level are present.