### PR TITLE
libscu-c: Allow specifying extra CFLAGS for valgrind

### DIFF
--- a/libscu-c/Makefile
+++ b/libscu-c/Makefile
@@ -2,6 +2,9 @@ CFLAGS:=-Wall -Wextra -Werror -I. -Wstrict-prototypes -Wmissing-prototypes
 
 ifneq ($(SCU_HAVE_VALGRIND),)
 CFLAGS+=-DSCU_HAVE_VALGRIND=1
+ifneq ($(SCU_VALGRIND_CFLAGS),)
+CFLAGS+=$(SCU_VALGRIND_CFLAGS)
+endif
 endif
 
 .PHONY: clean


### PR DESCRIPTION
This should help integration in buildsystems where valgrind is in a
non-standard location.