### PR TITLE
Ensure failures to initiate testmodule is detected

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-TESTCASES:=file framework crash crash-at-shutdown valgrind-error crash-in-setup crash-in-teardown
+TESTCASES:=file framework crash crash-at-shutdown valgrind-error crash-in-setup crash-in-teardown initfail
 
 CFLAGS=-Wall -Wextra -Werror -std=gnu11 -g
 

--- a/examples/initfail.c
+++ b/examples/initfail.c
@@ -1,0 +1,8 @@
+/* Don't use libscu-c's main - instead have one that never does anything useful */
+int
+main(int argc, char **argv)
+{
+	argc = argc;
+	argv = argv;
+	return 1;
+}

--- a/testrunner
+++ b/testrunner
@@ -401,9 +401,10 @@ class TestEmitter(Observer):
 
 class SummaryEmitter(Observer):
 
-    def __init__(self):
+    def __init__(self, module_init_failures):
         self.module_counter = 0
         self.module_fail_counter = 0
+        self.module_init_fail_counter = module_init_failures
         self.test_counter = 0
         self.test_fail_counter = 0
         self.assert_counter = 0
@@ -446,7 +447,9 @@ class SummaryEmitter(Observer):
             self.module_fail_counter += 1
 
     def is_failure(self):
-        return self.module_fail_counter > 0 or self.valgrind_errors_counter > 0
+        return any((self.module_fail_counter > 0,
+                    self.valgrind_errors_counter > 0,
+                    self.module_init_fail_counter > 0))
 
     def print_summary(self):
         print("\n  Run summary:\n")
@@ -462,8 +465,8 @@ class SummaryEmitter(Observer):
             "  +----------+------------+------------+------------+\n"
         ).format(
             self.module_counter - self.module_fail_counter,
-            self.module_fail_counter,
-            self.module_counter,
+            self.module_fail_counter + self.module_init_fail_counter,
+            self.module_counter + self.module_init_fail_counter,
             self.test_counter - self.test_fail_counter,
             self.test_fail_counter,
             self.test_counter,
@@ -711,6 +714,18 @@ if __name__ == '__main__':
     runner.list_modules()
     runner.deregister(collector)
 
+    module_init_failures = 0
+    for m in runner.modules:
+        if m.failed:
+            module_init_failures += 1
+            print("  {}".format(m.module_path))
+            print("    > {colors.RED}Module failed to initialize{colors.DEFAULT}"
+                  .format(colors=Colors))
+        elif not m.tests:
+            print("  {name}".format(name=m.name))
+            print("    > Module does not contain any tests"
+                  .format(colors=Colors))
+
     # Filter tests
     tests_to_run = []
     for m in runner.modules:
@@ -740,7 +755,7 @@ if __name__ == '__main__':
         xml_emitter = None
     buffered_emitter.register(TestCleaner())
 
-    summary_emitter = SummaryEmitter()
+    summary_emitter = SummaryEmitter(module_init_failures)
     runner.register(buffered_emitter)
     runner.register(summary_emitter)
 


### PR DESCRIPTION
If the testmodule crashed (or didn't start at all) when listing which
tests it contains the module was just skipped as if all tests in it had
been excluded.

Normally libscu-c has the main() function and doesn't run any user code
when listing tests. But a common scenario where this could happen is if
the testcase links with a shared library, and that isn't available in
library path when running the test.

This adds handling so that failed modules are detected and error is
propagated accordingly.