### PR TITLE
Add option to run all test cases

### DIFF
--- a/libscu-c/src/scu.c
+++ b/libscu-c/src/scu.c
@@ -442,7 +442,7 @@ parse_opt(int key, char *arg, struct argp_state *state)
 			break;
 		}
 		case ARGP_KEY_END:
-			if (!parsed_args->run && parsed_args->num_tests > 0)
+			if (!parsed_args->run && state->arg_num > 0)
 				argp_error(state, "extraneous arguments");
 			break;
 		default:

--- a/libscu-c/src/scu.c
+++ b/libscu-c/src/scu.c
@@ -409,7 +409,7 @@ typedef struct {
 
 static struct argp_option options[] = {
     {"list", 'l', 0, 0, "list available test cases", 0},
-    {"run", 'r', 0, 0, "run the test cases identified by the supplied indices", 0},
+    {"run", 'r', 0, 0, "run the test cases identified by the supplied indices, or all if none is supplied", 0},
     {0}};
 
 static error_t
@@ -427,8 +427,11 @@ parse_opt(int key, char *arg, struct argp_state *state)
 		case ARGP_KEY_NO_ARGS:
 			if (!parsed_args->list && !parsed_args->run)
 				argp_usage(state);
-			if (parsed_args->run)
-				argp_error(state, "not enough arguments");
+			if (parsed_args->run) {
+				for (size_t i = 0; i < _scu_module_num_tests; i++) {
+					parsed_args->test_indices[parsed_args->num_tests++] = i;
+				}
+			}
 			break;
 		case ARGP_KEY_ARG: {
 			errno = 0;


### PR DESCRIPTION
Currently the user has to specify a list of test cases to run in the
test module. In some scenarios it would be benefitial to run all
test cases, e.g. when debugging testcases in an environment where
gdbserver is not available.

Add option "--run-all" to enable this.

For this to work properly we first have to remove the implicit relationship between the
"parsed_args->num_tests" and the check for lack of arguments for "--run". Do this 
by utilizing the built in counter state->arg_num in argp.