### PR TITLE
Use fair scheduling in valgrind

### DIFF
--- a/testrunner
+++ b/testrunner
@@ -650,7 +650,7 @@ class Valgrind(Wrapper):
     extra_opts = property(lambda self: self.mainargs.valgrind_opt)
 
     def get_args(self, args):
-        outargs = ['valgrind', "--log-file={}".format(self.log_path)]
+        outargs = ['valgrind', "--log-file={}".format(self.log_path), "--fair-sched=try"]
         outargs += self.extra_opts
         outargs += args
         return outargs


### PR DESCRIPTION
Use fair scheduling if possible. There are issues with using std::thread in C++ otherwise as the default scheduling will always be biased toward the thread releasing a lock. This in turn may starve the other threads. This is noticable when performing conditional waits as valgrind tend to interrupt the wait often and this in turn will hog the mutex. Fair scheduling will do a round-robin approach instead. It's not always available so set it to "try".

See valgrind docs about "--fair-sched"