### PR TITLE
Give testrunner macOS-support

### DIFF
--- a/examples/initfail.c
+++ b/examples/initfail.c
@@ -2,7 +2,7 @@
 int
 main(int argc, char **argv)
 {
-	argc = argc;
-	argv = argv;
+	(void) argc;
+	(void) argv;
 	return 1;
 }

--- a/libscu-c/Makefile.scu
+++ b/libscu-c/Makefile.scu
@@ -16,8 +16,17 @@ build: $(TESTCASES)
 clean::
 	rm -f $(TESTCASES) $(patsubst %,%.o,$(TESTCASES)) $(patsubst %,valgrind.%.log,$(TESTCASES))
 
+
+LDFLAGS:=-L$(SCU_DIR)/libscu-c/ -lscu-c
+
+ifeq ($(shell uname), Darwin)
+	# libargp may be installed with homebrew
+	#    brew install argp-standalone
+	LDFLAGS+=-largp
+endif
+
 $(TESTCASES): %:%.o $(SCU_DIR)/libscu-c/libscu-c.a
-	$(CC) -o $@ $< -L$(SCU_DIR)/libscu-c/ -lscu-c
+	$(CC) -o $@ $< $(LDFLAGS)
 
 $(SCU_DIR)/libscu-c/libscu-c.a:
 	make -C $(SCU_DIR)/libscu-c

--- a/libscu-c/Makefile.scu
+++ b/libscu-c/Makefile.scu
@@ -17,7 +17,7 @@ clean::
 	rm -f $(TESTCASES) $(patsubst %,%.o,$(TESTCASES)) $(patsubst %,valgrind.%.log,$(TESTCASES))
 
 
-LDFLAGS:=-L$(SCU_DIR)/libscu-c/ -lscu-c
+LDFLAGS:=-L$(SCU_DIR)/libscu-c/ -lscu-c -lpthread
 
 ifeq ($(shell uname), Darwin)
 	# libargp may be installed with homebrew

--- a/libscu-c/src/scu.c
+++ b/libscu-c/src/scu.c
@@ -1,10 +1,10 @@
 #include <argp.h>
 #include <assert.h>
+#include <pthread.h>
 #include <setjmp.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
-#include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -296,13 +296,13 @@ _scu_get_time_diff(struct timespec startt, struct timespec endt)
 }
 
 static bool _scu_fatal_assert_jmpbuf_valid;
-static pid_t _scu_fatal_assert_allowed_thread_id;
+static pthread_t _scu_fatal_assert_allowed_thread_id;
 static jmp_buf _scu_fatal_assert_jmpbuf;
 
-static pid_t
+static pthread_t
 _scu_get_current_thread_id(void)
 {
-	return syscall(SYS_gettid);
+	return pthread_self();
 }
 
 void


### PR DESCRIPTION
A few things are missing in macOS to run test runner properly. Deal with them. Use pthread for thread-id instead of syscall. Add libargp as an explicit library when building under Darwin due to it not being part of the standard lib on macOS. Also address som compiler warnings running with apple clang.